### PR TITLE
MNT - Switch to Elastic Cox estimation 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@ This benchmark is dedicated to solver of **Cox estimation**:
 
 
 $$
-\\min_{w} \frac{1}{n} \\sum_{i=1}^{n} -s_i \\langle x_i, w \\rangle + \\log(\\textstyle\\sum_{y_j \\geq y_i} e^{\\langle x_j, w \\rangle})
-+ \\lambda \Big( \\rho \\lVert w \\rVert_1 \\frac{1-\\rho}{2} \\lVert w \\rVert^2_2 \Big)
+\\min_{w} \\frac{1}{n} \\sum_{i=1}^{n} -s_i \\langle x_i, w \\rangle + \\log(\\textstyle\\sum_{y_j \\geq y_i} e^{\\langle x_j, w \\rangle})
++ \\lambda \\Big( \\rho \\lVert w \\rVert_1 \\frac{1-\\rho}{2} \\lVert w \\rVert^2_2 \\Big)
 $$
 
 where $n$ (or ``n_samples``) stands for the number of samples, $p$ (or ``n_features``) stands for the number of features, $s$ the vector of observation censorship, $y$ occurrences times.
@@ -20,11 +20,11 @@ $$\\mathbf{X} \\in \\mathbb{R}^{n \\times p} \\ , \\, s \\in \\{ 0, 1 \\}^n, \\ 
 In the case of tied data, data with observation having the same occurrences time, the objective reads
 
 $$
-\\min_{w} \frac{1}{n} \\sum_{l=1}^{m} \\bigg(
+\\min_{w} \\frac{1}{n} \\sum_{l=1}^{m} \\bigg(
 \\sum_{i \\in H_{i_l}} - \\langle x_i, w \\rangle 
 + \\log \\Bigl(\\textstyle \\sum_{y_j \\geq y_{i_l}} e^{\\langle x_j, w \\rangle} - \\frac{\\#(i) - 1}{\\lvert H_{i_l} \\rvert}\\textstyle\\sum_{j \\in H_{i_l}} e^{\\langle x_j, w \\rangle}\\Bigl)
 \\bigg)
-+ \\lambda \Big( \\rho \\lVert w \\rVert_1 \\frac{1-\\rho}{2} \\lVert w \\rVert^2_2 \Big)
++ \\lambda \\Big( \\rho \\lVert w \\rVert_1 \\frac{1-\\rho}{2} \\lVert w \\rVert^2_2 \\Big)
 $$
 
 where $H_{i_l} = \\{ i \\ | \\ s_i = 1 \\ ;\\ y_{i} = y_{i_l} \\}$ is the set of uncensored observations with same occurrence time $y_{i_l}$ and $\\#(i)$ the index of observation $i$ in $H_{i_l}$.

--- a/README.rst
+++ b/README.rst
@@ -1,19 +1,20 @@
-Benchmark for L1-Cox estimation
+Benchmark for Cox estimation
 ===============================
 |Build Status| |Python 3.6+|
 
 
-This benchmark is dedicated to solver of **L1-Cox estimation**:
+This benchmark is dedicated to solver of **Cox estimation**:
 
 
 $$
-\\min_{w} \\sum_{i=1}^{n} -s_i \\langle x_i, w \\rangle + \\log(\\textstyle\\sum_{y_j \\geq y_i} e^{\\langle x_j, w \\rangle}) + \\lambda \\lVert w \\rVert_1
+\\min_{w} \\sum_{i=1}^{n} -s_i \\langle x_i, w \\rangle + \\log(\\textstyle\\sum_{y_j \\geq y_i} e^{\\langle x_j, w \\rangle})
++ \\lambda (\\rho \\lVert w \\rVert_1 \\frac{1-\\rho}{2} \\lVert w \rVert^2_2)
 $$
 
 where $n$ (or ``n_samples``) stands for the number of samples, $p$ (or ``n_features``) stands for the number of features, $s$ the vector of observation censorship, $y$ occurrences times.
 
 
-$$X \\in \\mathbb{R}^{n \\times p} \\ , \\, s \\in \\{ , 1 \\}^n, \\ , y \\in \\mathbb{R}^n, \\quad w \\in \\mathbb{R}^p$$
+$$\mathbf{X} \\in \\mathbb{R}^{n \\times p} \\ , \\, s \\in \\{ 0, 1 \\}^n, \\ , y \\in \\mathbb{R}^n, \\quad w \\in \\mathbb{R}^p$$
 
 
 In the case of tied data, data with observation having the same occurrences time, the objective reads
@@ -23,6 +24,7 @@ $$
 \\sum_{i \\in H_{i_l}} - \\langle x_i, w \\rangle 
 + \\log \\Bigl(\\textstyle \\sum_{y_j \\geq y_{i_l}} e^{\\langle x_j, w \\rangle} - \\frac{\\#(i) - 1}{\\lvert H_{i_l} \\rvert}\\textstyle\\sum_{j \\in H_{i_l}} e^{\\langle x_j, w \\rangle}\\Bigl)
 \\bigg)
++ \\lambda (\\rho \\lVert w \\rVert_1 \\frac{1-\\rho}{2} \\lVert w \rVert^2_2)
 $$
 
 where $H_{i_l} = \\{ i \\ | \\ s_i = 1 \\ ;\\ y_{i} = y_{i_l} \\}$ is the set of uncensored observations with same occurrence time $y_{i_l}$ and $\\#(i)$ the index of observation $i$ in $H_{i_l}$.

--- a/README.rst
+++ b/README.rst
@@ -7,24 +7,24 @@ This benchmark is dedicated to solver of **Cox estimation**:
 
 
 $$
-\\min_{w} \\sum_{i=1}^{n} -s_i \\langle x_i, w \\rangle + \\log(\\textstyle\\sum_{y_j \\geq y_i} e^{\\langle x_j, w \\rangle})
-+ \\lambda (\\rho \\lVert w \\rVert_1 \\frac{1-\\rho}{2} \\lVert w \rVert^2_2)
+\\min_{w} \frac{1}{n} \\sum_{i=1}^{n} -s_i \\langle x_i, w \\rangle + \\log(\\textstyle\\sum_{y_j \\geq y_i} e^{\\langle x_j, w \\rangle})
++ \\lambda \Big( \\rho \\lVert w \\rVert_1 \\frac{1-\\rho}{2} \\lVert w \\rVert^2_2 \Big)
 $$
 
 where $n$ (or ``n_samples``) stands for the number of samples, $p$ (or ``n_features``) stands for the number of features, $s$ the vector of observation censorship, $y$ occurrences times.
 
 
-$$\mathbf{X} \\in \\mathbb{R}^{n \\times p} \\ , \\, s \\in \\{ 0, 1 \\}^n, \\ , y \\in \\mathbb{R}^n, \\quad w \\in \\mathbb{R}^p$$
+$$\\mathbf{X} \\in \\mathbb{R}^{n \\times p} \\ , \\, s \\in \\{ 0, 1 \\}^n, \\ , y \\in \\mathbb{R}^n, \\quad w \\in \\mathbb{R}^p$$
 
 
 In the case of tied data, data with observation having the same occurrences time, the objective reads
 
 $$
-\\min_{w} \\sum_{l=1}^{m} \\bigg(
+\\min_{w} \frac{1}{n} \\sum_{l=1}^{m} \\bigg(
 \\sum_{i \\in H_{i_l}} - \\langle x_i, w \\rangle 
 + \\log \\Bigl(\\textstyle \\sum_{y_j \\geq y_{i_l}} e^{\\langle x_j, w \\rangle} - \\frac{\\#(i) - 1}{\\lvert H_{i_l} \\rvert}\\textstyle\\sum_{j \\in H_{i_l}} e^{\\langle x_j, w \\rangle}\\Bigl)
 \\bigg)
-+ \\lambda (\\rho \\lVert w \\rVert_1 \\frac{1-\\rho}{2} \\lVert w \rVert^2_2)
++ \\lambda \Big( \\rho \\lVert w \\rVert_1 \\frac{1-\\rho}{2} \\lVert w \\rVert^2_2 \Big)
 $$
 
 where $H_{i_l} = \\{ i \\ | \\ s_i = 1 \\ ;\\ y_{i} = y_{i_l} \\}$ is the set of uncensored observations with same occurrence time $y_{i_l}$ and $\\#(i)$ the index of observation $i$ in $H_{i_l}$.

--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -14,7 +14,7 @@ class Dataset(BaseDataset):
 
     parameters = {
         'n_samples, n_features': [
-            (100, 10),  # (500, 300), (1000, 500)
+            (200, 100), (500, 300), (1000, 500)
         ],
         'normalize': [True],
         'with_ties': [True, False],

--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -8,15 +8,13 @@ class Dataset(BaseDataset):
 
     name = "Simulated"
 
-    # TODO: replace `pip:git+https://github.com/Badr-MOUFAD/skglm.git`
-    # after merging skglm PR 159
     requirements = [
-        "pip:git+https://github.com/Badr-MOUFAD/skglm.git@cox-estimator",
+        "pip:git+https://github.com/scikit-learn-contrib/skglm.git@main",
     ]
 
     parameters = {
         'n_samples, n_features': [
-            (200, 100),  (500, 300),
+            (100, 10),  # (500, 300), (1000, 500)
         ],
         'normalize': [True],
         'with_ties': [True, False],

--- a/example_conf.yml
+++ b/example_conf.yml
@@ -5,7 +5,7 @@ solver:
 dataset:
   - Simulated
 
-timeout: 60
+timeout: 120
 max-runs: 1000
 n-repetitions: 1
 n-jobs: 18

--- a/objective.py
+++ b/objective.py
@@ -15,7 +15,7 @@ class Objective(BaseObjective):
 
     parameters = {
         'reg': [1e-1, 1e-2],
-        'l1_ratio': [1.]
+        'l1_ratio': [1., 0.7, 0.]
     }
 
     requirements = [
@@ -30,6 +30,7 @@ class Objective(BaseObjective):
 
     def set_data(self, tm, s, X, use_efron):
         n_samples = X.shape[0]
+        reg, l1_ratio = self.reg, self.l1_ratio
 
         self.X = X
         self.y = (tm, s)
@@ -41,7 +42,11 @@ class Objective(BaseObjective):
 
         # init alpha
         grad_0 = self.datafit.raw_grad(self.y, np.zeros(n_samples))
-        self.alpha = self.l1_ratio * self.reg * norm(X.T @ grad_0, ord=np.inf)
+
+        if l1_ratio != 0:
+            self.alpha = reg * norm(X.T @ grad_0, ord=np.inf) / l1_ratio
+        else:
+            self.alpha = reg * norm(X.T @ grad_0, ord=np.inf)
 
         # init penalty
         self.penalty = compiled_clone(L1_plus_L2(self.alpha, self.l1_ratio))

--- a/objective.py
+++ b/objective.py
@@ -64,7 +64,8 @@ class Objective(BaseObjective):
         tm, s = self.y
 
         return dict(
-            tm=tm, s=s, X=self.X, alpha=self.alpha,
+            tm=tm, s=s, X=self.X,
+            alpha=self.alpha, l1_ratio=self.l1_ratio,
             use_efron=self.use_efron
         )
 

--- a/objective.py
+++ b/objective.py
@@ -11,17 +11,15 @@ with safe_import_context() as import_ctx:
 
 class Objective(BaseObjective):
 
-    name = "L1 Cox Estimation"
+    name = "Cox Estimation"
 
     parameters = {
         'reg': [1e-1, 1e-2],
         'l1_ratio': [1.]
     }
 
-    # TODO: replace `pip:git+https://github.com/Badr-MOUFAD/skglm.git`
-    # after merging skglm PR 159
     requirements = [
-        "pip:git+https://github.com/Badr-MOUFAD/skglm.git@cox-efron",
+        "pip:git+https://github.com/scikit-learn-contrib/skglm.git@main",
     ]
 
     min_benchopt_version = "1.3"

--- a/solvers/lifelines.py
+++ b/solvers/lifelines.py
@@ -47,4 +47,4 @@ class Solver(BaseSolver):
     @staticmethod
     def get_next(previous):
         "Linear growth for n_iter."
-        return previous + 1
+        return previous + 10

--- a/solvers/lifelines.py
+++ b/solvers/lifelines.py
@@ -21,13 +21,13 @@ class Solver(BaseSolver):
         patience=10, strategy="iteration",
     )
 
-    def set_objective(self, tm, s, X, alpha, use_efron):
+    def set_objective(self, tm, s, X, alpha, l1_ratio, use_efron):
         # format data
         stacked_tm_s_X = np.hstack((tm[:, None], s[:, None], X))
         self.df = pd.DataFrame(stacked_tm_s_X)
 
         warnings.filterwarnings('ignore')
-        self.estimator = CoxPHFitter(penalizer=alpha, l1_ratio=1.)
+        self.estimator = CoxPHFitter(penalizer=alpha, l1_ratio=l1_ratio)
 
     def run(self, n_iter):
         self.estimator.fit(

--- a/solvers/skglm.py
+++ b/solvers/skglm.py
@@ -3,8 +3,8 @@ from benchopt import BaseSolver, safe_import_context
 
 with safe_import_context() as import_ctx:
     from skglm.datafits import Cox
-    from skglm.penalties import L1_plus_L2
-    from skglm.solvers import ProxNewton
+    from skglm.penalties import L1_plus_L2, L2
+    from skglm.solvers import ProxNewton, LBFGS
     from skglm.utils.jit_compilation import compiled_clone
 
 
@@ -12,25 +12,36 @@ class Solver(BaseSolver):
 
     name = 'skglm'
 
-    # TODO: replace `pip:git+https://github.com/Badr-MOUFAD/skglm.git`
-    # after merging skglm PR 159
+    parameters = {
+        "solver": ["Prox-Newton", 'L-BFGS']
+    }
+
     requirements = [
-        "pip:git+https://github.com/Badr-MOUFAD/skglm.git@cox-efron",
+        "pip:git+https://github.com/scikit-learn-contrib/skglm.git@main",
     ]
 
     stopping_strategy = 'iteration'
 
     def set_objective(self, tm, s, X, alpha, l1_ratio, use_efron):
         self.tm, self.s, self.X = tm, s, X
-
-        # fit ProxNewton
-        self.datafit = compiled_clone(Cox(use_efron))
-        self.penalty = compiled_clone(L1_plus_L2(alpha, l1_ratio))
-
-        self.datafit.initialize(X, (tm, s))
+        self.l1_ratio = l1_ratio
 
         warnings.filterwarnings('ignore')
-        self.solver = ProxNewton(fit_intercept=False, tol=1e-9)
+        if self.solver == "Proximal-Newton":
+            # fit ProxNewton
+            self.datafit = compiled_clone(Cox(use_efron))
+            self.penalty = compiled_clone(L1_plus_L2(alpha, l1_ratio))
+
+            self.datafit.initialize(X, (tm, s))
+            self.solver = ProxNewton(fit_intercept=False, tol=1e-9)
+        elif self.solver == "L-BFGS":
+            # L-BFGS
+            self.datafit = compiled_clone(Cox(use_efron))
+            self.penalty = compiled_clone(L2(alpha))
+
+            self.datafit.initialize(X, (tm, s))
+
+            self.solver = LBFGS(tol=1e-9)
 
         # cache numba compilation
         self.run(4)
@@ -41,14 +52,20 @@ class Solver(BaseSolver):
         w, *_ = self.solver.solve(
             self.X, (self.tm, self.s), self.datafit, self.penalty
         )
-
         self.w = w
 
     def get_result(self):
         return self.w
 
     def skip(self, tm, s, X, alpha, l1_ratio, use_efron):
-        if alpha == 0.:
-            return True, f"{self.name} does not handle unpenalized Cox estimation."
+        if alpha == 0. and self.solver == "Prox-Newton":
+            reason = (f"{self.name}:{self.solver} does not handle"
+                      " unpenalized Cox estimation.")
+            return True, reason
+
+        if l1_ratio != 0. and self.solver == "L-BFGS":
+            reason = (f"{self.name}:{self.solver} handles only "
+                      "L2 Cox regularization")
+            return True, reason
 
         return False, None

--- a/solvers/skglm.py
+++ b/solvers/skglm.py
@@ -3,7 +3,7 @@ from benchopt import BaseSolver, safe_import_context
 
 with safe_import_context() as import_ctx:
     from skglm.datafits import Cox
-    from skglm.penalties import L1
+    from skglm.penalties import L1_plus_L2
     from skglm.solvers import ProxNewton
     from skglm.utils.jit_compilation import compiled_clone
 
@@ -20,12 +20,12 @@ class Solver(BaseSolver):
 
     stopping_strategy = 'iteration'
 
-    def set_objective(self, tm, s, X, alpha, use_efron):
+    def set_objective(self, tm, s, X, alpha, l1_ratio, use_efron):
         self.tm, self.s, self.X = tm, s, X
 
         # fit ProxNewton
         self.datafit = compiled_clone(Cox(use_efron))
-        self.penalty = compiled_clone(L1(alpha))
+        self.penalty = compiled_clone(L1_plus_L2(alpha, l1_ratio))
 
         self.datafit.initialize(X, (tm, s))
 
@@ -46,3 +46,9 @@ class Solver(BaseSolver):
 
     def get_result(self):
         return self.w
+
+    def skip(self, tm, s, X, alpha, l1_ratio, use_efron):
+        if alpha == 0.:
+            return True, f"{self.name} does not handle unpenalized Cox estimation."
+
+        return False, None

--- a/solvers/skglm.py
+++ b/solvers/skglm.py
@@ -13,7 +13,7 @@ class Solver(BaseSolver):
     name = 'skglm'
 
     parameters = {
-        "solver": ["Prox-Newton", 'L-BFGS']
+        "solver": ["Prox-Newton", "L-BFGS"]
     }
 
     requirements = [
@@ -27,7 +27,7 @@ class Solver(BaseSolver):
         self.l1_ratio = l1_ratio
 
         warnings.filterwarnings('ignore')
-        if self.solver == "Proximal-Newton":
+        if self.solver == "Prox-Newton":
             # fit ProxNewton
             self.datafit = compiled_clone(Cox(use_efron))
             self.penalty = compiled_clone(L1_plus_L2(alpha, l1_ratio))
@@ -42,6 +42,11 @@ class Solver(BaseSolver):
             self.datafit.initialize(X, (tm, s))
 
             self.solver = LBFGS(tol=1e-9)
+        else:
+            raise ValueError(
+                f"Solver Parameter `{self.solver}` is not "
+                f" supported in {self.name}"
+            )
 
         # cache numba compilation
         self.run(4)


### PR DESCRIPTION
This update the benchmark repo to handle the case of elastic Cox estimation

$$
\lambda \Big( \rho \lVert w \rVert_1 + \frac{1 - \rho}{2} \lVert w \rVert^2_2 \Big)
$$

with $\rho$ aka. `l1_ratio` being in $[0, 1]$ and $\lambda \geq 0$.

It proceeds as follows
- [x] update readme
- [x] update objective and solvers
- [x] add `skglm.LBFGS`
  
Closes #2 