### PR TITLE
MNT - use ``(X, y)`` as data convention

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ $$
 where $n$ (or ``n_samples``) stands for the number of samples, $p$ (or ``n_features``) stands for the number of features, $s$ the vector of observation censorship, $y$ occurrences times.
 
 
-$$\\mathbf{X} \\in \\mathbb{R}^{n \\times p} \\ , \\, s \\in \\{ 0, 1 \\}^n, \\ , y \\in \\mathbb{R}^n, \\quad w \\in \\mathbb{R}^p$$
+$$\\mathbf{X} \\in \\mathbb{R}^{n \\times p} \\ , \\, s \\in \\{ 0, 1 \\}^n, \\ y \\in \\mathbb{R}^n, \\quad w \\in \\mathbb{R}^p$$
 
 
 In the case of tied data, data with observation having the same occurrences time, the objective reads

--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -29,8 +29,8 @@ class Dataset(BaseDataset):
         self.with_ties = with_ties
 
     def get_data(self):
-        tm, s, X = make_dummy_survival_data(
+        X, y = make_dummy_survival_data(
             self.n_samples, self.n_features, self.normalize,
             random_state=self.random_state, with_ties=self.with_ties)
 
-        return dict(tm=tm, s=s, X=X, use_efron=self.with_ties)
+        return dict(X=X, y=y, use_efron=self.with_ties)

--- a/example_conf.yml
+++ b/example_conf.yml
@@ -1,6 +1,7 @@
 solver:
   - skglm
   - lifelines
+  - scikit-survival
 
 dataset:
   - Simulated
@@ -8,4 +9,4 @@ dataset:
 timeout: 120
 max-runs: 1000
 n-repetitions: 1
-n-jobs: 18
+n-jobs: 2

--- a/objective.py
+++ b/objective.py
@@ -28,12 +28,11 @@ class Objective(BaseObjective):
         self.reg = reg
         self.l1_ratio = l1_ratio
 
-    def set_data(self, tm, s, X, use_efron):
+    def set_data(self, X, y, use_efron):
         n_samples = X.shape[0]
         reg, l1_ratio = self.reg, self.l1_ratio
 
-        self.X = X
-        self.y = (tm, s)
+        self.X, self.y = X, y
         self.use_efron = use_efron
 
         # init penalty
@@ -64,10 +63,8 @@ class Objective(BaseObjective):
         )
 
     def get_objective(self):
-        tm, s = self.y
-
         return dict(
-            tm=tm, s=s, X=self.X,
+            X=self.X, y=self.y,
             alpha=self.alpha, l1_ratio=self.l1_ratio,
             use_efron=self.use_efron
         )

--- a/solvers/lifelines.py
+++ b/solvers/lifelines.py
@@ -21,10 +21,10 @@ class Solver(BaseSolver):
         patience=10, strategy="iteration",
     )
 
-    def set_objective(self, tm, s, X, alpha, l1_ratio, use_efron):
+    def set_objective(self, X, y, alpha, l1_ratio, use_efron):
         # format data
-        stacked_tm_s_X = np.hstack((tm[:, None], s[:, None], X))
-        self.df = pd.DataFrame(stacked_tm_s_X)
+        stacked_y_X = np.hstack((y, X))
+        self.df = pd.DataFrame(stacked_y_X)
 
         warnings.filterwarnings('ignore')
         self.estimator = CoxPHFitter(penalizer=alpha, l1_ratio=l1_ratio)

--- a/solvers/sk_survival.py
+++ b/solvers/sk_survival.py
@@ -28,13 +28,14 @@ class Solver(BaseSolver):
         patience=10, strategy="iteration",
     )
 
-    def set_objective(self, tm, s, X, alpha, l1_ratio, use_efron):
-        self.tm, self.s, self.X = tm, s, X
+    def set_objective(self, X, y, alpha, l1_ratio, use_efron):
+        self.X, self.y = X, y
         self.l1_ratio = l1_ratio
         n_samples = X.shape[0]
 
         # cast data
         dtype = np.dtype([('fstat', bool), ('lenfol', '<f8')])
+        tm, s = y[:, 0], y[:, 1]
         self.y = np.array(list(
             zip(s, tm)
         ), dtype)
@@ -72,7 +73,7 @@ class Solver(BaseSolver):
     def get_result(self):
         return self.w.flatten()
 
-    def skip(self, tm, s, X, alpha, l1_ratio, use_efron):
+    def skip(self, X, y, alpha, l1_ratio, use_efron):
         if l1_ratio != 0 and use_efron:
             reason = (f"{self.name} does not handle tied data"
                       " for Elastic Cox estimation.")

--- a/solvers/skglm.py
+++ b/solvers/skglm.py
@@ -22,8 +22,8 @@ class Solver(BaseSolver):
 
     stopping_strategy = 'iteration'
 
-    def set_objective(self, tm, s, X, alpha, l1_ratio, use_efron):
-        self.tm, self.s, self.X = tm, s, X
+    def set_objective(self, X, y, alpha, l1_ratio, use_efron):
+        self.X, self.y = X, y
         self.l1_ratio = l1_ratio
 
         warnings.filterwarnings('ignore')
@@ -32,14 +32,14 @@ class Solver(BaseSolver):
             self.datafit = compiled_clone(Cox(use_efron))
             self.penalty = compiled_clone(L1_plus_L2(alpha, l1_ratio))
 
-            self.datafit.initialize(X, (tm, s))
+            self.datafit.initialize(X, y)
             self.solver = ProxNewton(fit_intercept=False, tol=1e-9)
         elif self.solver == "L-BFGS":
             # L-BFGS
             self.datafit = compiled_clone(Cox(use_efron))
             self.penalty = compiled_clone(L2(alpha))
 
-            self.datafit.initialize(X, (tm, s))
+            self.datafit.initialize(X, y)
 
             self.solver = LBFGS(tol=1e-9)
         else:
@@ -55,14 +55,14 @@ class Solver(BaseSolver):
         self.solver.max_iter = n_iter
 
         w, *_ = self.solver.solve(
-            self.X, (self.tm, self.s), self.datafit, self.penalty
+            self.X, self.y, self.datafit, self.penalty
         )
         self.w = w
 
     def get_result(self):
         return self.w
 
-    def skip(self, tm, s, X, alpha, l1_ratio, use_efron):
+    def skip(self, X, y, alpha, l1_ratio, use_efron):
         if alpha == 0. and self.solver == "Prox-Newton":
             reason = (f"{self.name}:{self.solver} does not handle"
                       " unpenalized Cox estimation.")


### PR DESCRIPTION
This aligns the data passed in to the objective and solvers with the new `skglm` scikit-learn-like convention https://github.com/scikit-learn-contrib/skglm/pull/175, ``(tm, s, X) --> (X, y)``

Thereby, it fixes the CI.
